### PR TITLE
Sprint/2020 09 28 (#16)

### DIFF
--- a/WineUp/WineUp/Extensions/Color+hex.swift
+++ b/WineUp/WineUp/Extensions/Color+hex.swift
@@ -1,0 +1,20 @@
+//
+//  Color+hex.swift
+//  WineUp
+//
+//  Created by Dmitry Rebrik on 04.10.2020.
+//
+
+import SwiftUI
+
+extension Color {
+    init(hex: UInt, alpha: Double = 1) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xff) / 255,
+            green: Double((hex >> 08) & 0xff) / 255,
+            blue: Double((hex >> 00) & 0xff) / 255,
+            opacity: alpha
+        )
+    }
+}

--- a/WineUp/WineUp/Modules/Catalog/Catalog/CatalogView.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/CatalogView.swift
@@ -31,9 +31,9 @@ struct CatalogView: View {
 struct CatalogView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            CatalogView()
+            CatalogView(searchText: "")
                 .previewDevice("iPhone 11 Pro")
-            CatalogView()
+            CatalogView(searchText: "")
         }
     }
 }

--- a/WineUp/WineUp/Modules/Catalog/Catalog/Filters/CharacteristicsFilter/CharacteristicsFilterItemButton.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/Filters/CharacteristicsFilter/CharacteristicsFilterItemButton.swift
@@ -1,0 +1,21 @@
+//
+//  CharacteristicsFilterItemButton.swift
+//  WineUp
+//
+//  Created by Влад on 05.10.2020.
+//
+
+import SwiftUI
+
+struct CharacteristicsFilterItemButton: View {
+    let item: CharacteristicsFilterItemModel
+    @State var isChecked: Bool = false
+    func action () {
+        isChecked.toggle()
+    }
+    var body: some View {
+        Button(action: action, label: {
+            CharacteristicsFilterItemView(item: item, isChecked: isChecked).padding(.leading)
+        })
+    }
+}

--- a/WineUp/WineUp/Modules/Catalog/Catalog/Filters/CharacteristicsFilter/CharacteristicsFilterItemView.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/Filters/CharacteristicsFilter/CharacteristicsFilterItemView.swift
@@ -1,0 +1,37 @@
+//
+//  CharacteristicsFilterItemView.swift
+//  WineUp
+//
+//  Created by Влад on 05.10.2020.
+//
+
+import SwiftUI
+
+struct CharacteristicsFilterItemModel: Identifiable {
+    var id = UUID()
+    var title: String
+}
+
+struct CharacteristicsFilterItemView: View {
+    let item: CharacteristicsFilterItemModel
+    var isChecked: Bool
+    let chColor = Color(red: 158 / 255.0, green: 51 / 255.0, blue: 75 / 255.0)
+    var body: some View {
+        VStack(alignment: .trailing) {
+            HStack(alignment: .center) {
+                Image(systemName: isChecked ? "checkmark.square.fill": "square").foregroundColor(isChecked ? chColor : .black)
+                Text(item.title).foregroundColor(.primary).font(.system(size: 13))
+            }
+        }.frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+#if DEBUG
+struct CharacteristicsFilterItemViewPreview: PreviewProvider {
+    private static let item = CharacteristicsFilterItemModel(title: "Test")
+    static var previews: some View {
+        return CharacteristicsFilterItemView(item: item, isChecked: false)
+            .previewLayout(.fixed(width: 400, height: 250))
+    }
+}
+#endif

--- a/WineUp/WineUp/Modules/Catalog/Catalog/Filters/CharacteristicsFilter/CharacteristicsFilterView.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/Filters/CharacteristicsFilter/CharacteristicsFilterView.swift
@@ -1,0 +1,45 @@
+//
+//  CharacteristicsFilterView.swift
+//  WineUp
+//
+//  Created by Влад on 05.10.2020.
+//
+
+import SwiftUI
+
+struct CharacteristicsFilterView: View {
+    var items: [CharacteristicsFilterItemModel]
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 15) {
+            ForEach(items) {  item in
+                CharacteristicsFilterItemButton(item: item)
+                    .frame(minWidth: 60, maxWidth: .infinity)
+                Divider()
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct CharacteristicsFilterViewPreviews: PreviewProvider {
+    private static let ColorItems = [
+        CharacteristicsFilterItemModel(title: "Белое"),
+        CharacteristicsFilterItemModel(title: "Красное"),
+        CharacteristicsFilterItemModel(title: "Розовое")
+    ]
+    private static let SugarItems = [
+        CharacteristicsFilterItemModel(title: "Сладкое"),
+        CharacteristicsFilterItemModel(title: "Полусладкое"),
+        CharacteristicsFilterItemModel(title: "Полусухое"),
+        CharacteristicsFilterItemModel(title: "Сухое")
+    ]
+    static var previews: some View {
+        Group {
+            CharacteristicsFilterView(items: ColorItems)
+                .previewLayout(.fixed(width: 400, height: 250))
+            CharacteristicsFilterView(items: SugarItems)
+                .previewLayout(.fixed(width: 400, height: 250))
+        }
+    }
+}
+#endif

--- a/WineUp/WineUp/Modules/Catalog/Catalog/Filters/PriceFilter/PriceFilterItemButton.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/Filters/PriceFilter/PriceFilterItemButton.swift
@@ -1,0 +1,29 @@
+//
+//  PriceFilterItemButton.swift
+//  WineUp
+//
+//  Created by Nikolai Solonenko on 02.10.2020.
+//
+
+import SwiftUI
+
+struct PriceFilterItemButton: View {
+    let item: PriceFilterItemModel
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action, label: {
+            PriceFilterItemView(item: item).padding()
+        })
+    }
+}
+
+#if DEBUG
+struct PriceFilterItemButtonPreview: PreviewProvider {
+    private static let item = PriceFilterItemModel(title: "Test value")
+    static var previews: some View {
+        return PriceFilterItemButton(item: item, action: {})
+            .previewLayout(.fixed(width: 414, height: 250))
+    }
+}
+#endif

--- a/WineUp/WineUp/Modules/Catalog/Catalog/Filters/PriceFilter/PriceFilterItemView.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/Filters/PriceFilter/PriceFilterItemView.swift
@@ -1,0 +1,45 @@
+//
+//
+//  PriceFilterItems.swift
+//  WineUp
+//
+//  Created by Nikolai Solonenko on 02.10.2020.
+//
+
+import SwiftUI
+
+struct PriceFilterItemModel: Identifiable {
+    var id = UUID()
+    var title: String
+}
+
+struct PriceFilterItemView: View {
+
+    // MARK: - State
+
+    let item: PriceFilterItemModel
+
+    // MARK: - View
+
+    var body: some View {
+        Text(item.title)
+            .foregroundColor(.primary)
+            .font(.system(size: 13))
+            .overlay(
+                RoundedRectangle(cornerRadius: 25)
+                    .stroke(Color(.systemGray4), lineWidth: 1)
+                    .padding([.leading, .trailing], -10)
+                    .padding([.top, .bottom], -10)
+            )
+    }
+}
+
+#if DEBUG
+struct PriceFilterItemViewPreview: PreviewProvider {
+    private static let item = PriceFilterItemModel(title: "Test value")
+    static var previews: some View {
+        return PriceFilterItemView(item: item)
+            .previewLayout(.fixed(width: 414, height: 250))
+    }
+}
+#endif

--- a/WineUp/WineUp/Modules/Catalog/Catalog/Filters/PriceFilter/PriceFilterView.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/Filters/PriceFilter/PriceFilterView.swift
@@ -1,0 +1,77 @@
+//
+//  PriceFilterView.swift
+//  WineUp
+//
+//  Created by Nikolai Solonenko on 02.10.2020.
+//
+
+import SwiftUI
+
+struct PriceFilterView: View {
+
+    // MARK: - State
+
+    @State private var fromPrice: String = ""
+    @State private var toPrice: String = ""
+    @State private var toggleSwitch = false
+    var items: [PriceFilterItemModel]
+    var onItemTap: OnItemTap?
+
+    // MARK: - View
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10, content: {
+            HStack(alignment: .center, spacing: 15, content: {
+                VStack(alignment: .leading, spacing: 10, content: {
+                    Text("От").foregroundColor(.gray)
+                    TextField("0000", text: $fromPrice)
+                    Divider()
+                })
+
+                VStack(alignment: .leading, spacing: 10, content: {
+                    Text("До").foregroundColor(.gray)
+                    TextField("0000", text: $toPrice)
+                    Divider()
+                })
+            })
+
+            Toggle(isOn: $toggleSwitch) {
+                Text("Товар со скидкой")
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0.0) {
+                    ForEach(items) { item in
+                        PriceFilterItemButton(item: item, action: { self.itemDidTap(item) })
+                            .frame(minWidth: 60, maxWidth: .infinity)
+                    }
+                }
+            }.frame(minWidth: 0, maxWidth: .infinity, minHeight: 60, maxHeight: 60, alignment: .center)
+        }).padding(.leading, 5)
+        .padding(.trailing, 10)
+    }
+
+    // MARK: - Actions
+
+    typealias OnItemTap = (PriceFilterItemModel) -> Void
+
+    private func itemDidTap(_ item: PriceFilterItemModel) {
+        onItemTap?(item)
+    }
+}
+
+#if DEBUG
+struct PriceFilterViewPreviews: PreviewProvider {
+    private static let items = [
+        PriceFilterItemModel(title: "До 1500"),
+        PriceFilterItemModel(title: "1500-3000"),
+        PriceFilterItemModel(title: "3000-5000"),
+        PriceFilterItemModel(title: "5000-10000"),
+        PriceFilterItemModel(title: "Больше 1000")
+    ]
+    static var previews: some View {
+        return PriceFilterView(items: items, onItemTap: nil)
+            .previewLayout(.fixed(width: 414, height: 250))
+    }
+}
+#endif

--- a/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationFilter.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationFilter.swift
@@ -1,0 +1,52 @@
+//
+//  RecommendationFilter.swift
+//  WineUp
+//
+//  Created by Dmitry Rebrik on 04.10.2020.
+//
+
+import SwiftUI
+
+private extension CGFloat {
+    static let titlePadding: CGFloat = 20
+    static let listSpacing: CGFloat = 10
+    static let listLeading: CGFloat = 60
+    static let listPaddingTop: CGFloat = 10
+}
+
+struct RecommendationFilter: View {
+
+    // MARK: - View
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text("Рекомендованное")
+                    .padding([.top, .leading], .titlePadding)
+                    .font(Font.title.bold())
+                Spacer()
+            }
+            RecommendationFilterList(viewModel: listViewModel,
+                                     spacing: .listSpacing)
+                .padding(.leading, .listLeading)
+                .padding(.top, .listPaddingTop)
+            Spacer()
+        }
+    }
+
+    // MARK: - Private
+
+    private var listViewModel: RecommendationFilterList.ViewModel {
+        return .init(variants: ["Наиболее вам подходящие",
+                                "По рейтингу"])
+    }
+}
+
+#if DEBUG
+struct RecommendationFilter_Previews: PreviewProvider {
+    static var previews: some View {
+        RecommendationFilter()
+            .previewLayout(.fixed(width: 420, height: 300))
+    }
+}
+#endif

--- a/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationFilterList+ViewModel.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationFilterList+ViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  RecommendationFilterList+ViewModel.swift
+//  WineUp
+//
+//  Created by Dmitry Rebrik on 04.10.2020.
+//
+
+import SwiftUI
+
+// MARK: - RecommendationFilterList+ViewModel
+
+extension RecommendationFilterList {
+
+    class ViewModel: ObservableObject {
+
+        // Properties
+        @Published var variants: [Item]
+        @Published var pickedItem: Item?
+
+        // MARK: - Init
+
+        init(variants: [String]) {
+            self.variants = variants.map { Item(text: $0) }
+        }
+
+        // MARK: Public
+
+        public func didItemTapped(item: Item) {
+            guard pickedItem?.id != item.id else {
+                pickedItem = nil
+                return
+            }
+            self.pickedItem = item
+        }
+    }
+
+    struct Item: Identifiable, Equatable {
+        let id = UUID()
+        let text: String
+    }
+}

--- a/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationFilterList.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationFilterList.swift
@@ -1,0 +1,40 @@
+//
+//  RecommendationFilterList.swift
+//  WineUp
+//
+//  Created by Dmitry Rebrik on 04.10.2020.
+//
+
+import SwiftUI
+
+struct RecommendationFilterList: View {
+
+    // Properties
+    @ObservedObject var viewModel: ViewModel
+    var spacing: CGFloat?
+
+    // MARK: - View
+
+    var body: some View {
+        VStack(spacing: spacing) {
+            ForEach(viewModel.variants) { item in
+                RecommendationItemView(item: item,
+                                       pickedItem: $viewModel.pickedItem)
+                    .onTapGesture {
+                        viewModel.didItemTapped(item: item)
+                    }
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct RecommendationFilterList_Previews: PreviewProvider {
+
+    static var previews: some View {
+        RecommendationFilterList(viewModel: .init(variants: ["Наиболее вам подходящие",
+                                                             "По рейтингу"]))
+            .previewLayout(.fixed(width: 420, height: 300))
+    }
+}
+#endif

--- a/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationItemView.swift
+++ b/WineUp/WineUp/Modules/Catalog/Catalog/RecommendationFilter/RecommendationItemView.swift
@@ -1,0 +1,72 @@
+//
+//  RecommendationItemView.swift
+//  WineUp
+//
+//  Created by Dmitry Rebrik on 04.10.2020.
+//
+
+import SwiftUI
+
+private extension CGFloat {
+    static let checkmarkSize: CGFloat = 18.0
+}
+
+struct RecommendationItemView: View {
+
+    // Properties
+    let item: RecommendationFilterList.Item
+    @Binding var pickedItem: RecommendationFilterList.Item?
+
+    // MARK: - View
+
+    var body: some View {
+        HStack {
+            checkmarkImage
+                .resizable()
+                .frame(width: .checkmarkSize, height: .checkmarkSize)
+                .foregroundColor(checkmarkColor)
+            Text(item.text)
+                .font(.title3)
+            Spacer()
+        }
+    }
+
+    // MARK: - Private
+
+    private var checkmarkImage: Image {
+        Image(systemName: isPicked ? "checkmark.square" : "square")
+    }
+
+    private var checkmarkColor: Color {
+        isPicked ? .init(hex: 0x006400) : .black
+    }
+
+    private var isPicked: Bool {
+        guard let pickedItem = pickedItem else { return false }
+        return pickedItem.id == item.id
+    }
+}
+
+#if DEBUG
+struct RecommendationItemView_Previews: PreviewProvider {
+
+    @ObservedObject static var viewModel: RecommendationFilterList.ViewModel = {
+        let viewModel =
+            RecommendationFilterList.ViewModel(variants: ["Наиболее вам подходящие",
+                                                          "По рейтингу"])
+        viewModel.pickedItem = viewModel.variants[0]
+        return viewModel
+    }()
+
+    static var previews: some View {
+        Group {
+            RecommendationItemView(item: viewModel.variants[0], pickedItem: $viewModel.pickedItem)
+                .previewLayout(.fixed(width: 300, height: 50))
+
+            RecommendationItemView(item: viewModel.variants[1], pickedItem: $viewModel.pickedItem)
+                .previewLayout(.fixed(width: 300, height: 50))
+        }
+
+    }
+}
+#endif


### PR DESCRIPTION
* [UI-4-price-filter] add price filer as view (#13)

* UI-4-price-filter add price filer as view

* UI-4-price-filter pr comments fix

* UI-4: Fixed last Trailing Whitespace warnings and #if paddings

Co-authored-by: Aleksandr Pakhomov <twofoursixeight@yandex.ru>

* UI-6 recommendation filter (#14)

* UI-5-added-color-sugar-filters (#15)

* UI-5-added-color-sugar-filters

* UI-5 Bug fixes

1) Добавлены заголовки файлов
2) UI реализация фильтров по цвету и количеству сахара объединена в один
3) Исправлены ошибки в коде

Co-authored-by: Nikolai Solonenko <70380928+nsolonenko@users.noreply.github.com>
Co-authored-by: dimonker <37213685+dimonker@users.noreply.github.com>
Co-authored-by: Vlad-9 <39233500+Vlad-9@users.noreply.github.com>